### PR TITLE
Playing sounds as alarms option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,15 @@ Then simply call this to play system default notification sound:
 FlutterRingtonePlayer.playNotification();
 ```
 
-You can also specify some additional parameters (works only on Android with API 28 and above):
-
-```dart
-FlutterRingtonePlayer.playNotification(volume: 0.5, looping: true);
-```
-
 There's also this generic method allowing you to specify in detail what kind of ringtone should be played:
 
 ```dart
 FlutterRingtonePlayer.play(
   android: AndroidSounds.notification,
   ios: IosSounds.glass,
-  looping: true,
-  volume: 0.1,
+  looping: true, // Android only - API >= 28
+  volume: 0.1, // Android only - API >= 28
+  asAlarm: false, // Android only - all APIs
 );
 
 ```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ FlutterRingtonePlayer.play(
 
 ```
 
+### .play*() optional attributes
+
+| Attribute       |  Description |
+| --------------  | ------------ |
+| `bool` looping  | Enables looping of ringtone. Requires `FlutterRingtonePlayer.stop();` to stop ringing. |
+| `double` volume | Sets ringtone volume in range 0 to 1.0. |
+| `bool` asAlarm  | Allows to ignore device's silent/vibration mode and play given sound anyway. |
+
+
 To stop looped ringtone please use:
 
 ```dart

--- a/android/src/main/java/io/inway/ringtone/player/FlutterRingtonePlayerPlugin.java
+++ b/android/src/main/java/io/inway/ringtone/player/FlutterRingtonePlayerPlugin.java
@@ -71,6 +71,7 @@ public class FlutterRingtonePlayerPlugin implements MethodCallHandler {
                     ringtone.stop();
                 }
                 ringtone = ringtoneManager.getRingtone(context, ringtoneUri);
+                ringtone.setStreamType(AudioManager.STREAM_ALARM);
 
                 if (call.hasArgument("volume")) {
                     final double volume = call.argument("volume");

--- a/android/src/main/java/io/inway/ringtone/player/FlutterRingtonePlayerPlugin.java
+++ b/android/src/main/java/io/inway/ringtone/player/FlutterRingtonePlayerPlugin.java
@@ -1,6 +1,7 @@
 package io.inway.ringtone.player;
 
 import android.content.Context;
+import android.media.AudioManager;
 import android.media.Ringtone;
 import android.media.RingtoneManager;
 import android.net.Uri;

--- a/android/src/main/java/io/inway/ringtone/player/FlutterRingtonePlayerPlugin.java
+++ b/android/src/main/java/io/inway/ringtone/player/FlutterRingtonePlayerPlugin.java
@@ -72,7 +72,6 @@ public class FlutterRingtonePlayerPlugin implements MethodCallHandler {
                     ringtone.stop();
                 }
                 ringtone = ringtoneManager.getRingtone(context, ringtoneUri);
-                ringtone.setStreamType(AudioManager.STREAM_ALARM);
 
                 if (call.hasArgument("volume")) {
                     final double volume = call.argument("volume");
@@ -85,6 +84,20 @@ public class FlutterRingtonePlayerPlugin implements MethodCallHandler {
                     final boolean looping = call.argument("looping");
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                         ringtone.setLooping(looping);
+                    }
+                }
+
+                if (call.hasArgument("asAlarm")) {
+                    final boolean asAlarm = call.argument("asAlarm");
+                    /* There's also a .setAudioAttributes method
+                       that is more flexible, but .setStreamType
+                       is supported in all Android versions
+                       whereas .setAudioAttributes needs SDK > 21.
+                       More on that at
+                       https://developer.android.com/reference/android/media/Ringtone
+                    */
+                    if (asAlarm) {
+                        ringtone.setStreamType(AudioManager.STREAM_ALARM);
                     }
                 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-
 import 'package:flutter_ringtone_player/flutter_ringtone_player.dart';
 
 void main() => runApp(MyApp());
@@ -21,6 +20,15 @@ class MyApp extends StatelessWidget {
                   child: const Text('playAlarm'),
                   onPressed: () {
                     FlutterRingtonePlayer.playAlarm();
+                  },
+                ),
+              ),
+              Padding(
+                padding: EdgeInsets.all(8),
+                child: RaisedButton(
+                  child: const Text('playAlarm asAlarm: false'),
+                  onPressed: () {
+                    FlutterRingtonePlayer.playAlarm(asAlarm: false);
                   },
                 ),
               ),

--- a/lib/flutter_ringtone_player.dart
+++ b/lib/flutter_ringtone_player.dart
@@ -24,15 +24,19 @@ class FlutterRingtonePlayer {
   /// This is generic method allowing you to specify individual sounds
   /// you wish to be played for each platform
   ///
+  /// [asAlarm] is an Android only flag that lets play given sound
+  /// as an alarm, that is, phone will make sound even if
+  /// it is in silent or vibration mode.
+  ///
   /// See also:
   ///  * [AndroidSounds]
   ///  * [IosSounds]
-  static Future<void> play({
-    @required AndroidSound android,
-    @required IosSound ios,
-    double volume,
-    bool looping,
-  }) async {
+  static Future<void> play(
+      {@required AndroidSound android,
+      @required IosSound ios,
+      double volume,
+      bool looping,
+      bool asAlarm}) async {
     try {
       var args = <String, dynamic>{
         'android': android.value,
@@ -40,46 +44,41 @@ class FlutterRingtonePlayer {
       };
       if (looping != null) args['looping'] = looping;
       if (volume != null) args['volume'] = volume;
+      if (asAlarm != null) args['asAlarm'] = asAlarm;
 
       _channel.invokeMethod('play', args);
     } on PlatformException {}
   }
 
   /// Play default alarm sound (looping on Android)
-  static Future<void> playAlarm({
-    double volume,
-    bool looping = true,
-  }) async =>
+  static Future<void> playAlarm(
+          {double volume, bool looping = true, bool asAlarm = true}) async =>
       play(
-        android: AndroidSounds.alarm,
-        ios: IosSounds.alarm,
-        volume: volume,
-        looping: looping,
-      );
+          android: AndroidSounds.alarm,
+          ios: IosSounds.alarm,
+          volume: volume,
+          looping: looping,
+          asAlarm: asAlarm);
 
   /// Play default notification sound
-  static Future<void> playNotification({
-    double volume,
-    bool looping,
-  }) async =>
+  static Future<void> playNotification(
+          {double volume, bool looping, bool asAlarm = false}) async =>
       play(
-        android: AndroidSounds.notification,
-        ios: IosSounds.triTone,
-        volume: volume,
-        looping: looping,
-      );
+          android: AndroidSounds.notification,
+          ios: IosSounds.triTone,
+          volume: volume,
+          looping: looping,
+          asAlarm: asAlarm);
 
   /// Play default system ringtone (looping on Android)
-  static Future<void> playRingtone({
-    double volume,
-    bool looping = true,
-  }) async =>
+  static Future<void> playRingtone(
+          {double volume, bool looping = true, bool asAlarm = false}) async =>
       play(
-        android: AndroidSounds.ringtone,
-        ios: IosSounds.electronic,
-        volume: volume,
-        looping: looping,
-      );
+          android: AndroidSounds.ringtone,
+          ios: IosSounds.electronic,
+          volume: volume,
+          looping: looping,
+          asAlarm: asAlarm);
 
   /// Stop looping sounds like alarms & ringtones on Android.
   /// This is no-op on iOS.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   charcode:
     dependency: transitive
     description:
@@ -52,28 +52,28 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.1.7"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.2"
+    version: "1.6.4"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0+1"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,7 +106,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   term_glyph:
     dependency: transitive
     description:
@@ -136,4 +136,4 @@ packages:
     source: hosted
     version: "2.0.8"
 sdks:
-  dart: ">=2.2.0 <3.0.0"
+  dart: ">=2.2.2 <3.0.0"


### PR DESCRIPTION
New argument for `.play()` method that allows to ignore device's silent/vibration mode and play sound. I've set a `.playAlarm()` method to use `asAlarm: true` as default, so this update can be considered breaking. Also, I've updated the README and bumped `pubspec.lock` versions - this change is breaking too so bumping library version to 2.0.0 may be necessary. If you don't want to do that, `pubspec.lock` changes can be reverted - it should not affect negatively the changes I've made.