### PR TITLE
A possible fix/workaround for "Null check operator used on a null value" when calling play()

### DIFF
--- a/lib/flutter_ringtone_player.dart
+++ b/lib/flutter_ringtone_player.dart
@@ -45,7 +45,8 @@ class FlutterRingtonePlayer {
       if (volume != null) args['volume'] = volume;
       if (asAlarm != null) args['asAlarm'] = asAlarm;
 
-      _channel.invokeMethod('play', args);
+      await Future.delayed(Duration(seconds: 1));
+	  _channel.invokeMethod('play', args);
     } on PlatformException {}
   }
 


### PR DESCRIPTION
`"Null check operator used on a null value"` received when `play()` is called with Flutter SDK version 2.2.3. Fix or the workaround is to wait 1 second before calling the `invokeMethod`.

Stack trace
`E/flutter ( 6232): Null check operator used on a null value
E/flutter ( 6232): #0      MethodChannel.binaryMessenger (package:flutter/src/services/platform_channel.dart:142:86)
E/flutter ( 6232): #1      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:148:36)
E/flutter ( 6232): #2      MethodChannel.invokeMethod (package:flutter/src/services/platform_channel.dart:331:12)
E/flutter ( 6232): #3      FlutterRingtonePlayer.play (package:flutter_ringtone_player/flutter_ringtone_player.dart:49:16)
E/flutter ( 6232): #4      FlutterRingtonePlayer.playAlarm (package:flutter_ringtone_player/flutter_ringtone_player.dart:56:7)`

I already has `WidgetsFlutterBinding.ensureInitialized();` as the 1st line in the `main()`. But still received the above error before adding the delay.

Doctor summary (to see all details, run flutter doctor -v):
[√] Flutter (Channel stable, 2.2.3, on Microsoft Windows [Version 10.0.19042.985], locale en-US)
[√] Android toolchain - develop for Android devices (Android SDK version 30.0.3)
[√] Chrome - develop for the web
[√] Android Studio (version 4.1.0)