### PR TITLE
[Issues#25] Android V2 embedding (Fixed)

### DIFF
--- a/android/src/main/java/io/inway/ringtone/player/FlutterRingtonePlayerPlugin.java
+++ b/android/src/main/java/io/inway/ringtone/player/FlutterRingtonePlayerPlugin.java
@@ -8,6 +8,10 @@ import android.net.Uri;
 import android.os.Build;
 import android.provider.Settings;
 
+import androidx.annotation.NonNull;
+
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -17,27 +21,43 @@ import io.flutter.plugin.common.PluginRegistry.Registrar;
 /**
  * FlutterRingtonePlayerPlugin
  */
-public class FlutterRingtonePlayerPlugin implements MethodCallHandler {
-    private final Context context;
-    private final RingtoneManager ringtoneManager;
+public class FlutterRingtonePlayerPlugin implements MethodCallHandler, FlutterPlugin {
+    private Context context;
+    private MethodChannel methodChannel;
+    private RingtoneManager ringtoneManager;
     private Ringtone ringtone;
-
-    public FlutterRingtonePlayerPlugin(Context context) {
-        this.context = context;
-        this.ringtoneManager = new RingtoneManager(context);
-        this.ringtoneManager.setStopPreviousRingtone(true);
-    }
 
     /**
      * Plugin registration.
      */
+    @SuppressWarnings("deprecation")
     public static void registerWith(Registrar registrar) {
-        final MethodChannel channel = new MethodChannel(registrar.messenger(), "flutter_ringtone_player");
-        channel.setMethodCallHandler(new FlutterRingtonePlayerPlugin(registrar.context()));
+        new FlutterRingtonePlayerPlugin().onAttachedToEngine(registrar.context(), registrar.messenger());
     }
 
     @Override
-    public void onMethodCall(MethodCall call, Result result) {
+    public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+        onAttachedToEngine(binding.getApplicationContext(), binding.getBinaryMessenger());
+    }
+
+    private void onAttachedToEngine(Context applicationContext, BinaryMessenger messenger) {
+        this.context = applicationContext;
+        this.ringtoneManager = new RingtoneManager(context);
+        this.ringtoneManager.setStopPreviousRingtone(true);
+
+        methodChannel = new MethodChannel(messenger, "flutter_ringtone_player");
+        methodChannel.setMethodCallHandler(this);
+    }
+
+    @Override
+    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+        context = null;
+        methodChannel.setMethodCallHandler(null);
+        methodChannel = null;
+    }
+
+    @Override
+    public void onMethodCall(@NonNull MethodCall call,@NonNull Result result) {
         try {
             Uri ringtoneUri = null;
 


### PR DESCRIPTION
I have fixed [[Issues#25]](https://github.com/inway/flutter_ringtone_player/issues/25)
Below is exact error that i have fixed in this P.R

```
The plugin `flutter_ringtone_player` uses a deprecated version of the Android embedding.
To avoid unexpected runtime failures, or future build failures, try to see if this plugin supports the Android V2 embedding. Otherwise, consider removing it since a future release of Flutter will remove these deprecated APIs.
If you are plugin author, take a look at the docs for migrating the plugin to the V2 embedding: https://flutter.dev/go/android-plugin-migration.
```