### PR TITLE
FIX #76 - Example App Uses Old SDK Version

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     if (project.android.hasProperty("namespace")) {
         namespace "io.inway.ringtone.player_example"


### PR DESCRIPTION
updated the compiledSdkVersion to 34, as the plugin path_provider needs this version