### PR TITLE
Removes Flutter v1 android embedding references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0+4
+
+- Removes references to Flutter v1 android embedding classes.
+
 ## 4.0.0+3
 
 - Moved `flutter_lints` to `dev_dependencies` to resolve [#80](https://github.com/inway/flutter_ringtone_player/issues/80)

--- a/android/src/main/java/io/inway/ringtone/player/FlutterRingtonePlayerPlugin.java
+++ b/android/src/main/java/io/inway/ringtone/player/FlutterRingtonePlayerPlugin.java
@@ -17,7 +17,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /**
  * FlutterRingtonePlayerPlugin

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -38,7 +38,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.inway.ringtone.player_example"
-        minSdkVersion 16
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_ringtone_player
 description: A simple player for system default ringtones, alarms and notifications
-version: 4.0.0+3
+version: 4.0.0+4
 homepage: https://github.com/inway/flutter_ringtone_player
 repository: https://github.com/inway/flutter_ringtone_player
 


### PR DESCRIPTION
Fixes https://github.com/inway/flutter_ringtone_player/issues/81.

Tested by building the flutter_ringtone_player example app with the changes in https://github.com/flutter/engine/pull/52022 applied. 
